### PR TITLE
Some improvements to the settings menus

### DIFF
--- a/css/deltagreen.css
+++ b/css/deltagreen.css
@@ -465,6 +465,16 @@ explicitly define a number of rows, rather than columns. */
   background-color: rgba(0, 0, 0, 0.185);
 }
 
+.deltagreen[id^="dg-settings"] {
+  .window-content > div.flexcol {
+    gap: 1rem;
+  }
+
+  .form-group label {
+    flex: unset;
+  }
+}
+
 a.btn-tiny {
   height: 26px;
   margin-left: 5px;

--- a/lang/en.json
+++ b/lang/en.json
@@ -390,18 +390,21 @@
   "DG.Settings.skillImprovementFormula.2": "+1D3%",
   "DG.Settings.skillImprovementFormula.3": "+1D4%",
   "DG.Settings.skillImprovementFormula.4": "+1D4-1%",
-  "DG.Settings.alwaysShowHypergeometrySectionForPlayers.name": "Always Show Hypergeometry Section for Players",
+  "DG.Settings.alwaysShowHypergeometrySectionForPlayers.name": "Show Hypergeometry Section",
   "DG.Settings.alwaysShowHypergeometrySectionForPlayers.hint": "Always show Hypergeometry item section (i.e., Rituals and Tomes) on Agent sheets, even if the Agent has no items of those types.",
   "DG.Settings.showImpossibleLandscapesContent.name": "Show Impossible Landscapes Content",
   "DG.Settings.showImpossibleLandscapesContent.hint": "Show Impossible Landscapes-specific fields in Agent sheets. These fields are only ever visible to the Handler, even if this setting is checked.",
   "DG.Settings.skillFailure.name": "Auto-mark Skill Failure",
   "DG.Settings.skillFailure.hint": "Activate this setting to always mark a failure checkbox upon failing a skill. The Handler can undo the action from the chat message for the roll.",
+  "DG.Settings.Saved": "The current settings have been saved.",
 
   "DG.SettingsMenu.automation.name": "Automation Menu",
   "DG.SettingsMenu.automation.label": "Automation Menu",
+  "DG.SettingsMenu.automation.title": "Automation Settings",
 
   "DG.SettingsMenu.handler.name": "Handler Settings",
   "DG.SettingsMenu.handler.label": "Handler Settings",
+  "DG.SettingsMenu.handler.title": "Handler-only Settings",
 
   "DG.Messages.Skillsmark.Marked": "This skill is marked",
   "DG.Messages.Skillsmark.Tooltip": "See p. 29 Agent's Handbook"

--- a/module/settings.js
+++ b/module/settings.js
@@ -205,7 +205,7 @@ class AutomationSettings extends SettingForm {
   /** @override */
   static DEFAULT_OPTIONS = {
     id: `${super.DEFAULT_OPTIONS.id}-${this.namespace ?? ""}`,
-    window: { title: "Automation Settings" },
+    window: { title: "DG.SettingsMenu.automation.title" },
   };
 
   /** @override */
@@ -231,7 +231,7 @@ class HandlerSettings extends SettingForm {
   /** @override */
   static DEFAULT_OPTIONS = {
     id: `${super.DEFAULT_OPTIONS.id}-${this.namespace ?? ""}`,
-    window: { title: "Handler-only Settings" },
+    window: { title: "DG.SettingsMenu.handler.title" },
   };
 
   /** @override */

--- a/module/settings.js
+++ b/module/settings.js
@@ -77,13 +77,16 @@ const SettingForm = class extends HandlebarsApplicationMixin(ApplicationV2) {
   /** @override */
   static async onSubmit(event, form, formData) {
     event.preventDefault();
+    // Get form data into a standard object.
     const data = foundry.utils.expandObject(formData.object);
 
     const settingsPromises = [];
+    // Set each setting with the new value, if any.
     for (const [key, value] of Object.entries(data)) {
       settingsPromises.push(game.settings.set(DG.ID, key, value));
     }
 
+    // Once all promises resolve, show a notification.
     Promise.allSettled(settingsPromises).then((values) => {
       ui.notifications.info(game.i18n.localize("DG.Settings.Saved"));
     });
@@ -93,6 +96,7 @@ const SettingForm = class extends HandlebarsApplicationMixin(ApplicationV2) {
   async _prepareContext(_options) {
     const context = await super._prepareContext(_options);
 
+    // Get Foundry's built-in input creation functions.
     const {
       createCheckboxInput,
       createNumberInput,
@@ -102,9 +106,13 @@ const SettingForm = class extends HandlebarsApplicationMixin(ApplicationV2) {
     } = foundry.applications.fields;
     context.formGroups = [];
 
+    // Iterate over each setting and create the appropriate input element.
     const { settings } = this.constructor;
     for (const settingID of Object.keys(settings)) {
-      const settingConfig = game.settings.settings.get(`${DG.ID}.${settingID}`); // The setting config object, not the value.
+      // The setting config object, not the value of the setting itself.
+      const settingConfig = game.settings.settings.get(`${DG.ID}.${settingID}`);
+
+      // Default input settings.
       const inputConfig = {
         name: `${DG.ID}.${settingID}`,
         value: game.settings.get(DG.ID, settingID), // The value that the setting is currently set to.

--- a/module/settings.js
+++ b/module/settings.js
@@ -111,6 +111,7 @@ const SettingForm = class extends HandlebarsApplicationMixin(ApplicationV2) {
     // Create a div element whose inner html is the form groups (as a string of HTML),
     // and prepend it to the window content.
     const div = document.createElement("div");
+    div.classList.add("flexcol");
     div.innerHTML = formGroupString;
     windowContent.prepend(div);
   }

--- a/module/settings.js
+++ b/module/settings.js
@@ -92,8 +92,8 @@ const SettingForm = class extends HandlebarsApplicationMixin(ApplicationV2) {
   }
 
   /** @override */
-  _onRender(options) {
-    super._onRender(options);
+  _onFirstRender(options) {
+    super._onFirstRender(options);
 
     this._attachFormGroupHTML();
   }

--- a/module/settings.js
+++ b/module/settings.js
@@ -81,7 +81,7 @@ const SettingForm = class extends HandlebarsApplicationMixin(ApplicationV2) {
 
     const settingsPromises = [];
     // Set each setting with the new value, if any.
-    for (const [key, value] of Object.entries(data)) {
+    for (const [key, value] of Object.entries(data[DG.ID])) {
       settingsPromises.push(game.settings.set(DG.ID, key, value));
     }
 

--- a/module/settings.js
+++ b/module/settings.js
@@ -7,7 +7,7 @@ const SettingForm = class extends HandlebarsApplicationMixin(ApplicationV2) {
   static _namespace;
 
   static get namespace() {
-    return this.constructor._namespace;
+    return this._namespace;
   }
 
   static get settings() {
@@ -27,9 +27,10 @@ const SettingForm = class extends HandlebarsApplicationMixin(ApplicationV2) {
     }
   }
 
+  /** @override */
   static DEFAULT_OPTIONS = {
     tag: "form",
-    id: `dg-settings`,
+    id: "deltagreen-settings",
     classes: [DG.ID, "settings-menu"],
     window: { contentClasses: ["standard-form"], resizable: true },
     position: { width: 500, height: "auto" },
@@ -41,6 +42,7 @@ const SettingForm = class extends HandlebarsApplicationMixin(ApplicationV2) {
     },
   };
 
+  /** @override */
   static PARTS = {
     form: { template: `systems/${DG.ID}/templates/settings.hbs` },
     footer: { template: `systems/${DG.ID}/templates/save.hbs` },
@@ -128,7 +130,7 @@ class AutomationSettings extends SettingForm {
   static _namespace = "automation";
 
   static DEFAULT_OPTIONS = {
-    id: `${super.DEFAULT_OPTIONS.id}-automation`,
+    id: `${super.DEFAULT_OPTIONS.id}-${this.namespace ?? ""}`,
     window: { title: "Automation Settings" },
   };
 
@@ -146,7 +148,7 @@ class HandlerSettings extends SettingForm {
   static _namespace = "handler";
 
   static DEFAULT_OPTIONS = {
-    id: `${super.DEFAULT_OPTIONS.id}-handler`,
+    id: `${super.DEFAULT_OPTIONS.id}-${this.namespace ?? ""}`,
     window: { title: "Handler-only Settings" },
   };
 

--- a/module/settings.js
+++ b/module/settings.js
@@ -56,7 +56,7 @@ const SettingForm = class extends HandlebarsApplicationMixin(ApplicationV2) {
   /** @override */
   static DEFAULT_OPTIONS = {
     tag: "form",
-    id: "deltagreen-settings",
+    id: "dg-settings",
     classes: [DG.ID, "settings-menu"],
     window: { contentClasses: ["standard-form"], resizable: true },
     position: { width: 500, height: "auto" },
@@ -70,7 +70,6 @@ const SettingForm = class extends HandlebarsApplicationMixin(ApplicationV2) {
 
   /** @override */
   static PARTS = {
-    form: { template: `systems/${DG.ID}/templates/settings.hbs` },
     footer: { template: `systems/${DG.ID}/templates/save.hbs` },
   };
 
@@ -93,9 +92,34 @@ const SettingForm = class extends HandlebarsApplicationMixin(ApplicationV2) {
   }
 
   /** @override */
-  async _prepareContext(_options) {
-    const context = await super._prepareContext(_options);
+  _onRender(options) {
+    super._onRender(options);
 
+    this._attachFormGroupHTML();
+  }
+
+  /**
+   * Populate the window content section with form groups representing the settings.
+   * @returns {void}
+   */
+  _attachFormGroupHTML() {
+    const windowContent = this.element.querySelector("section.window-content");
+    const formGroupString = this._prepareFormGroupElements()
+      .map((formGroup) => formGroup.outerHTML)
+      .join("");
+
+    // Create a div element whose inner html is the form groups (as a string of HTML),
+    // and prepend it to the window content.
+    const div = document.createElement("div");
+    div.innerHTML = formGroupString;
+    windowContent.prepend(div);
+  }
+
+  /**
+   * Generates an array of form groups, each corresponding to a setting in a menu.
+   * @returns {HTMLDivElement[]} An array of form group HTML elements.
+   */
+  _prepareFormGroupElements() {
     // Get Foundry's built-in input creation functions.
     const {
       createCheckboxInput,
@@ -104,7 +128,7 @@ const SettingForm = class extends HandlebarsApplicationMixin(ApplicationV2) {
       createTextInput,
       createFormGroup,
     } = foundry.applications.fields;
-    context.formGroups = [];
+    const formGroups = [];
 
     // Iterate over each setting and create the appropriate input element.
     const { settings } = this.constructor;
@@ -153,7 +177,7 @@ const SettingForm = class extends HandlebarsApplicationMixin(ApplicationV2) {
 
       // Create a Form Group, which generates all of the HTML for a single setting.
       // It includes a label and hint.
-      context.formGroups.push(
+      formGroups.push(
         createFormGroup({
           input,
           hint: settingConfig.hint,
@@ -164,7 +188,7 @@ const SettingForm = class extends HandlebarsApplicationMixin(ApplicationV2) {
       );
     }
 
-    return context;
+    return formGroups;
   }
 };
 

--- a/templates/settings.hbs
+++ b/templates/settings.hbs
@@ -1,21 +1,5 @@
 <div>
-  {{#each settings as |setting|}}
-    <div class="form-group">
-      <label for="{{setting.key}}">{{localize setting.name}}</label>
-      {{#if setting.isSelect}}
-        <select name="{{setting.key}}">
-          {{selectOptions setting.choices selected=setting.value localize=true}}
-        </select>
-      {{else if setting.isCheckbox}}
-        <input type="checkbox" name="{{setting.key}}" {{checked setting.value}} />
-      {{else if setting.isNumber}}
-        <input type="number" name="{{setting.key}}" value="{{setting.value}}" data-dtype="{{setting.type}}" />
-      {{else if setting.isString}}
-        <input type="text" name="{{setting.key}}" value="{{setting.value}}" data-dtype="{{setting.type}}" />
-      {{/if}}
-      {{#if setting.hint}}
-        <p class="hint">{{localize setting.hint}}</p>
-      {{/if}}
-    </div>
+  {{#each formGroups as |formGroup| }}
+    {{{formGroup.outerHTML}}}
   {{/each}}
 </div>

--- a/templates/settings.hbs
+++ b/templates/settings.hbs
@@ -1,5 +1,0 @@
-<div>
-  {{#each formGroups as |formGroup| }}
-    {{{formGroup.outerHTML}}}
-  {{/each}}
-</div>


### PR DESCRIPTION
First off, thanks for all your work so far. it is very good, and I appreciate you being amenable to my suggestions. I noticed that there is a better, more Foundry-like way to prepare the inputs for the settings menu; that is, by using Foundry's built-in input/select creation functions together with their `createFormGroup` function. That way we don't really need the handlebars template, and it's less for us to maintain. Instead we just have a function that generates the html for these form groups, and another function that attaches this html to the window content on first render. 

This PR also includes some miscellaneous changes:
- Added localization for window titles and the notification.
- Utilizes the `namespace` property to give each custom settings dialog its own ID. This allows both dialogs to be opened at the same time.
- Added comments and JSDocs
- Light styling